### PR TITLE
Add state to app.jsx

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -1,21 +1,64 @@
 import React from 'react';
+import axios from 'axios';
 import Overview from './Overview/Overview';
 import RatingsAndReviews from './Ratings_Reviews/Ratings_Reviews';
 import RelatedItems from './RelatedItems/RelatedItems';
 import Questions from './questions/Questions';
 
-function App() {
-  return (
-    <div>
-      Hello World!
-      <div>
-        <Overview />
-        <RelatedItems />
-        <Questions />
-        <RatingsAndReviews />
-      </div>
-    </div>
-  );
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      productID: 0,
+      apiResponse: false,
+    };
+
+    this.setProductID = this.setProductID.bind(this);
+  }
+
+  componentDidMount() {
+    axios({
+      method: 'GET',
+      url: '/api/all_products',
+      params: {
+        page: 1,
+        count: 10,
+      },
+    }).then((response) => {
+      this.setState({
+        productID: response.data[0].id,
+      });
+      // console.log(response.data[0].id);
+    }).then(() => {
+      this.setState({ apiResponse: true });
+    });
+  }
+
+  setProductID(id) {
+    this.setState({ productID: id });
+  }
+
+  render() {
+    if (this.state.apiResponse) {
+      return (
+        <div id="App" className="App">
+          <Overview
+            productID={this.state.productID}
+          />
+          <RelatedItems
+            productID={this.state.productID}
+          />
+          <Questions
+            productID={this.state.productID}
+          />
+          <RatingsAndReviews
+            productID={this.state.productID}
+          />
+        </div>
+      );
+    }
+    return <div>{' '}</div>;
+  }
 }
 
 export default App;

--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,15 @@ app.use(express.json());
 const headers = { authorization: auth.key };
 const baseUrl = 'https://app-hrsei-api.herokuapp.com/api/fec2/hr-rfp';
 
+// GET ALL PRODUCTS
+app.get('/api/all_products', (req, res) => {
+  axios({
+    method: 'GET',
+    url: `${baseUrl}/products/`,
+    headers,
+  }).then((axiosResponse) => res.send(axiosResponse.data));
+});
+
 // GET PRODUCT
 app.get('/api/product', (req, res) => {
   axios({


### PR DESCRIPTION
Refactored App to be a state component.  On the App component mounting, it will make an API request to get all products (actually, just the first 10).  It'll then store one of their product ID's (for now, always the first product) in state.  

The API call will also change the 'apiResponse' state value to true.  The point of this - we don't want to render our components until we've got a product back from the api.  You can see where that's used in the render() method.

Once the apiResponse is set to true, render() will paint our app, passing down the appropriate productID as props.  We can then each use this (instead of hardcoding) in our components to fill out the data.  We can also add more items to state if we need to access data across multiple components.

I've also created a setProductID(id) method which can be passed as props, if this should be useful for relatedProducts... so if you click on a related product, you can call that method, pass in a new product id, and have the whole app refresh to that product's page.